### PR TITLE
SUP-111 remove unnecessary value field from workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,5 +91,7 @@ jobs:
           TF_ACC: "1"
           ENTITLE_API_KEY: ${{ secrets.ENTITLE_API_KEY }}
           ENTITLE_OWNER_EMAIL: ${{ secrets.ENTITLE_OWNER_EMAIL }}
-        run: go test -v -cover -tags=acceptance ./internal/provider/
+          ENTITLE_OWNER_ID: ${{ secrets.ENTITLE_OWNER_ID }}
+          ENTITLE_WORKFLOW_ID: ${{ secrets.ENTITLE_WORKFLOW_ID }}
+        run: go test -v -cover -tags=acceptance ./internal/provider/...
         timeout-minutes: 10

--- a/docs/data-sources/workflow.md
+++ b/docs/data-sources/workflow.md
@@ -65,7 +65,6 @@ Read-Only:
 - `schedule` (Attributes) Approver schedule details (see [below for nested schema](#nestedatt--rules--approval_flow--steps--approval_entities--schedule))
 - `type` (String) Approver type
 - `user` (Attributes) Approver user details (see [below for nested schema](#nestedatt--rules--approval_flow--steps--approval_entities--user))
-- `value` (Attributes) Arbitrary value for approval logic (see [below for nested schema](#nestedatt--rules--approval_flow--steps--approval_entities--value))
 
 <a id="nestedatt--rules--approval_flow--steps--approval_entities--group"></a>
 ### Nested Schema for `rules.approval_flow.steps.approval_entities.group`
@@ -94,14 +93,6 @@ Read-Only:
 - `id` (String) Approver user's unique identifier
 
 
-<a id="nestedatt--rules--approval_flow--steps--approval_entities--value"></a>
-### Nested Schema for `rules.approval_flow.steps.approval_entities.value`
-
-Read-Only:
-
-- `approval` (String) Approval value
-
-
 
 <a id="nestedatt--rules--approval_flow--steps--notified_entities"></a>
 ### Nested Schema for `rules.approval_flow.steps.notified_entities`
@@ -112,7 +103,6 @@ Read-Only:
 - `schedule` (Attributes) Notified schedule details (see [below for nested schema](#nestedatt--rules--approval_flow--steps--notified_entities--schedule))
 - `type` (String) Entity type
 - `user` (Attributes) Notified user details (see [below for nested schema](#nestedatt--rules--approval_flow--steps--notified_entities--user))
-- `value` (Attributes) Arbitrary value for notification logic (see [below for nested schema](#nestedatt--rules--approval_flow--steps--notified_entities--value))
 
 <a id="nestedatt--rules--approval_flow--steps--notified_entities--group"></a>
 ### Nested Schema for `rules.approval_flow.steps.notified_entities.group`
@@ -139,14 +129,6 @@ Read-Only:
 
 - `email` (String) Notified user's email
 - `id` (String) Notified user's unique identifier
-
-
-<a id="nestedatt--rules--approval_flow--steps--notified_entities--value"></a>
-### Nested Schema for `rules.approval_flow.steps.notified_entities.value`
-
-Read-Only:
-
-- `notified` (String) Notified value
 
 
 

--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -27,9 +27,6 @@ resource "entitle_workflow" "example" {
             approval_entities = [
               {
                 type = "Automatic"
-                value = {
-                  approval = null
-                }
               }
             ]
             notified_entities = []
@@ -95,24 +92,12 @@ Optional:
 <a id="nestedatt--rules--approval_flow--steps--approval_entities"></a>
 ### Nested Schema for `rules.approval_flow.steps.approval_entities`
 
-Required:
-
-- `value` (Attributes) Holds additional metadata or configuration related to the entity’s role in the approval step. This can include specific rules, conditions, or statuses that influence how the approval or notification behaves. (see [below for nested schema](#nestedatt--rules--approval_flow--steps--approval_entities--value))
-
 Optional:
 
 - `group` (Attributes) Represents a group whose members are responsible for approving the permission request at this step. (see [below for nested schema](#nestedatt--rules--approval_flow--steps--approval_entities--group))
 - `schedule` (Attributes) Schedule applied to the approval entity. (see [below for nested schema](#nestedatt--rules--approval_flow--steps--approval_entities--schedule))
 - `type` (String) Type of approval entity.
 - `user` (Attributes) Represents an individual user who is required to approve the permission request at this step. (see [below for nested schema](#nestedatt--rules--approval_flow--steps--approval_entities--user))
-
-<a id="nestedatt--rules--approval_flow--steps--approval_entities--value"></a>
-### Nested Schema for `rules.approval_flow.steps.approval_entities.value`
-
-Optional:
-
-- `approval` (String) Specifies the approval condition or requirement for the entity in this step. For example, it could indicate whether the approval is mandatory, optional, or has a certain threshold. This field helps customize the approval logic at a granular level.
-
 
 <a id="nestedatt--rules--approval_flow--steps--approval_entities--group"></a>
 ### Nested Schema for `rules.approval_flow.steps.approval_entities.group`
@@ -160,7 +145,6 @@ Optional:
 - `schedule` (Attributes) Schedule applied to the approval entity. (see [below for nested schema](#nestedatt--rules--approval_flow--steps--notified_entities--schedule))
 - `type` (String) Type of notified entity
 - `user` (Attributes) Represents an individual user who will be notified during this step of the approval process. (see [below for nested schema](#nestedatt--rules--approval_flow--steps--notified_entities--user))
-- `value` (Attributes) value (see [below for nested schema](#nestedatt--rules--approval_flow--steps--notified_entities--value))
 
 <a id="nestedatt--rules--approval_flow--steps--notified_entities--group"></a>
 ### Nested Schema for `rules.approval_flow.steps.notified_entities.group`
@@ -196,14 +180,6 @@ Optional:
 Read-Only:
 
 - `email` (String) Email address of the notified user.
-
-
-<a id="nestedatt--rules--approval_flow--steps--notified_entities--value"></a>
-### Nested Schema for `rules.approval_flow.steps.notified_entities.value`
-
-Optional:
-
-- `notified` (String)
 
 
 

--- a/examples/resources/entitle_workflow/resource.tf
+++ b/examples/resources/entitle_workflow/resource.tf
@@ -9,9 +9,6 @@ resource "entitle_workflow" "example" {
             approval_entities = [
               {
                 type = "Automatic"
-                value = {
-                  approval = null
-                }
               }
             ]
             notified_entities = []

--- a/internal/provider/workflows/models.go
+++ b/internal/provider/workflows/models.go
@@ -47,26 +47,9 @@ func (m workflowRulesApprovalFlowStepNotifiedEntityModel) AsObjectValue(
 	return types.ObjectValueFrom(ctx, m.attributeTypes(), m)
 }
 
-type workflowRulesApprovalFlowStepApprovalEntityModel struct {
-	Approval types.String `tfsdk:"approval" json:"approval"`
-}
-
-func (m workflowRulesApprovalFlowStepApprovalEntityModel) attributeTypes() map[string]attr.Type {
-	return map[string]attr.Type{
-		"approval": types.StringType,
-	}
-}
-
-func (m workflowRulesApprovalFlowStepApprovalEntityModel) AsObjectValue(
-	ctx context.Context,
-) (basetypes.ObjectValue, diag.Diagnostics) {
-	return types.ObjectValueFrom(ctx, m.attributeTypes(), m)
-}
-
 type workflowRulesApprovalFlowStepApprovalNotifiedModel struct {
 	Type     types.String `tfsdk:"type" json:"type"`
 	User     types.Object `tfsdk:"user" json:"user"`
 	Group    types.Object `tfsdk:"group" json:"group"`
 	Schedule types.Object `tfsdk:"schedule" json:"schedule"`
-	Value    types.Object `tfsdk:"value" json:"value"`
 }

--- a/internal/provider/workflows/utils.go
+++ b/internal/provider/workflows/utils.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/entitleio/terraform-provider-entitle/internal/client"
@@ -181,22 +180,9 @@ func getWorkflowsRules(
 						string(client.EnumApprovalEntityWithoutEntityResourceOwner),
 						string(client.EnumApprovalEntityWithoutEntityTeamMember),
 						string(client.EnumApprovalEntityWithoutEntityAutomatic):
-						target := workflowRulesApprovalFlowStepApprovalEntityModel{
-							Approval: types.StringNull(),
-						}
-						if !entity.Value.IsNull() {
-							diagsAs := entity.Value.As(ctx, &target, basetypes.ObjectAsOptions{
-								UnhandledUnknownAsEmpty: true,
-							})
-							if diagsAs.HasError() {
-								diags.Append(diagsAs...)
-								return rules, diags
-							}
-						}
-
 						item, err := convertApprovalToApprovalFlowSchema(
 							entity.Type.ValueString(),
-							target.Approval.ValueStringPointer(),
+							nil,
 						)
 						if err != nil {
 							diags.AddError(
@@ -339,22 +325,9 @@ func getWorkflowsRules(
 						string(client.EnumNotifiedEntityWithoutEntityResourceMaintainer),
 						string(client.EnumNotifiedEntityWithoutEntityResourceOwner),
 						string(client.EnumNotifiedEntityWithoutEntityTeamMember):
-						target := workflowRulesApprovalFlowStepNotifiedEntityModel{
-							Notified: types.StringNull(),
-						}
-						if !entity.Value.IsNull() {
-							diagsAs := entity.Value.As(ctx, &target, basetypes.ObjectAsOptions{
-								UnhandledUnknownAsEmpty: true,
-							})
-							if diagsAs.HasError() {
-								diags.Append(diagsAs...)
-								return rules, diags
-							}
-						}
-
 						item, err := convertApprovalToNotifiedFlowSchema(
 							entity.Type.ValueString(),
-							target.Notified.ValueStringPointer(),
+							nil,
 						)
 						if err != nil {
 							diags.AddError(

--- a/internal/provider/workflows/workflow_data_source.go
+++ b/internal/provider/workflows/workflow_data_source.go
@@ -209,18 +209,6 @@ func (d *WorkflowDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 															Description:         "Notified schedule details",
 															MarkdownDescription: "Notified schedule details",
 														},
-														"value": schema.SingleNestedAttribute{
-															Attributes: map[string]schema.Attribute{
-																"notified": schema.StringAttribute{
-																	Computed:            true,
-																	Description:         "Notified value",
-																	MarkdownDescription: "Notified value",
-																},
-															},
-															Computed:            true,
-															Description:         "Arbitrary value for notification logic",
-															MarkdownDescription: "Arbitrary value for notification logic",
-														},
 													},
 												},
 												Computed:            true,
@@ -285,18 +273,6 @@ func (d *WorkflowDataSource) Schema(ctx context.Context, req datasource.SchemaRe
 															Computed:            true,
 															Description:         "Approver schedule details",
 															MarkdownDescription: "Approver schedule details",
-														},
-														"value": schema.SingleNestedAttribute{
-															Attributes: map[string]schema.Attribute{
-																"approval": schema.StringAttribute{
-																	Computed:            true,
-																	Description:         "Approval value",
-																	MarkdownDescription: "Approval value",
-																},
-															},
-															Computed:            true,
-															Description:         "Arbitrary value for approval logic",
-															MarkdownDescription: "Arbitrary value for approval logic",
 														},
 													},
 												},
@@ -432,14 +408,6 @@ func converterWorkflow(
 		return WorkflowDataSourceModel{}, diags
 	}
 
-	nullApprovalEntity, diagsAs := workflowRulesApprovalFlowStepApprovalEntityModel{
-		Approval: types.StringNull(),
-	}.AsObjectValue(ctx)
-	if diagsAs.HasError() {
-		diags.Append(diagsAs...)
-		return WorkflowDataSourceModel{}, diags
-	}
-
 	var rules []*workflowRulesModel
 	if len(data.Rules) > 0 {
 		rules = make([]*workflowRulesModel, 0, len(data.Rules))
@@ -534,7 +502,6 @@ func converterWorkflow(
 								Schedule: vObj,
 								User:     types.ObjectNull((&utils.IdEmailModel{}).AttributeTypes()),
 								Group:    types.ObjectNull((&utils.IdNameModel{}).AttributeTypes()),
-								Value:    types.ObjectNull((&workflowRulesApprovalFlowStepNotifiedEntityModel{}).attributeTypes()),
 							})
 						case string(client.EnumApprovalEntityUserUserUser):
 							val, err := entity.AsApprovalEntityUserResponseSchema()
@@ -573,7 +540,6 @@ func converterWorkflow(
 								User:     vObj,
 								Group:    types.ObjectNull((&utils.IdNameModel{}).AttributeTypes()),
 								Schedule: types.ObjectNull((&utils.IdNameModel{}).AttributeTypes()),
-								Value:    types.ObjectNull((&workflowRulesApprovalFlowStepNotifiedEntityModel{}).attributeTypes()),
 							})
 						case string(client.DirectoryGroup):
 							val, err := entity.AsApprovalEntityGroupResponseSchema()
@@ -602,7 +568,6 @@ func converterWorkflow(
 								Group:    vObj,
 								User:     types.ObjectNull((&utils.IdEmailModel{}).AttributeTypes()),
 								Schedule: types.ObjectNull((&utils.IdNameModel{}).AttributeTypes()),
-								Value:    types.ObjectNull((&workflowRulesApprovalFlowStepNotifiedEntityModel{}).attributeTypes()),
 							})
 						case string(client.EnumApprovalEntityWithoutEntityDirectManager),
 							string(client.EnumApprovalEntityWithoutEntityIntegrationOwner),
@@ -621,25 +586,8 @@ func converterWorkflow(
 								return WorkflowDataSourceModel{}, diags
 							}
 
-							v := workflowRulesApprovalFlowStepNotifiedEntityModel{
-								Notified: types.StringPointerValue(val.Entity),
-							}
-
-							if val.Entity == nil {
-								v = workflowRulesApprovalFlowStepNotifiedEntityModel{
-									Notified: types.StringNull(),
-								}
-							}
-
-							vObj, diagsAs := v.AsObjectValue(ctx)
-							if diagsAs.HasError() {
-								diags.Append(diagsAs...)
-								return WorkflowDataSourceModel{}, diags
-							}
-
 							flowStep.NotifiedEntities = append(flowStep.NotifiedEntities, &workflowRulesApprovalFlowStepApprovalNotifiedModel{
 								Type:     utils.TrimmedStringValue(string(val.Type)),
-								Value:    vObj,
 								User:     types.ObjectNull((&utils.IdEmailModel{}).AttributeTypes()),
 								Schedule: types.ObjectNull((&utils.IdNameModel{}).AttributeTypes()),
 								Group:    types.ObjectNull((&utils.IdNameModel{}).AttributeTypes()),
@@ -701,7 +649,6 @@ func converterWorkflow(
 								Type:     utils.TrimmedStringValue(string(val.Type)),
 								Schedule: vObj,
 								User:     types.ObjectNull((&utils.IdEmailModel{}).AttributeTypes()),
-								Value:    nullApprovalEntity,
 								Group:    types.ObjectNull((&utils.IdNameModel{}).AttributeTypes()),
 							})
 						case string(client.EnumApprovalEntityUserUserUser):
@@ -740,7 +687,6 @@ func converterWorkflow(
 								Type:     utils.TrimmedStringValue(string(val.Type)),
 								User:     vObj,
 								Schedule: types.ObjectNull((&utils.IdNameModel{}).AttributeTypes()),
-								Value:    nullApprovalEntity,
 								Group:    types.ObjectNull((&utils.IdNameModel{}).AttributeTypes()),
 							})
 						case string(client.DirectoryGroup):
@@ -770,7 +716,6 @@ func converterWorkflow(
 								Group:    vObj,
 								User:     types.ObjectNull((&utils.IdEmailModel{}).AttributeTypes()),
 								Schedule: types.ObjectNull((&utils.IdNameModel{}).AttributeTypes()),
-								Value:    nullApprovalEntity,
 							})
 						case string(client.EnumApprovalEntityWithoutEntityDirectManager),
 							string(client.EnumApprovalEntityWithoutEntityIntegrationOwner),
@@ -789,28 +734,11 @@ func converterWorkflow(
 								return WorkflowDataSourceModel{}, diags
 							}
 
-							v := workflowRulesApprovalFlowStepApprovalEntityModel{
-								Approval: types.StringPointerValue(val.Entity),
-							}
-
-							if val.Entity == nil {
-								v = workflowRulesApprovalFlowStepApprovalEntityModel{
-									Approval: types.StringNull(),
-								}
-							}
-
-							vObj, diagsAs := v.AsObjectValue(ctx)
-							if diagsAs.HasError() {
-								diags.Append(diagsAs...)
-								return WorkflowDataSourceModel{}, diags
-							}
-
 							flowStep.ApprovalEntities = append(flowStep.ApprovalEntities, &workflowRulesApprovalFlowStepApprovalNotifiedModel{
 								Type:     utils.TrimmedStringValue(string(val.Type)),
 								User:     types.ObjectNull((&utils.IdEmailModel{}).AttributeTypes()),
 								Schedule: types.ObjectNull((&utils.IdNameModel{}).AttributeTypes()),
 								Group:    types.ObjectNull((&utils.IdNameModel{}).AttributeTypes()),
-								Value:    vObj,
 							})
 						}
 					}

--- a/internal/provider/workflows/workflow_data_source_test.go
+++ b/internal/provider/workflows/workflow_data_source_test.go
@@ -1,0 +1,39 @@
+//go:build acceptance
+// +build acceptance
+
+package workflows_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/entitleio/terraform-provider-entitle/internal/testhelpers"
+)
+
+func TestWorkflowDataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Read testing
+			{
+				Config: testhelpers.ProviderConfig + fmt.Sprintf(`
+data "entitle_workflow" "my_workflow" {
+	id = "%s"
+}
+`, os.Getenv("ENTITLE_WORKFLOW_ID")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify
+					resource.TestCheckResourceAttr("data.entitle_workflow.my_workflow", "id", os.Getenv("ENTITLE_WORKFLOW_ID")),
+
+					// Verify dynamic values have any value set in the state.
+					resource.TestCheckResourceAttrSet("data.entitle_workflow.my_workflow", "name"),
+					resource.TestCheckResourceAttrSet("data.entitle_workflow.my_workflow", "rules.#"),
+					resource.TestCheckResourceAttrSet("data.entitle_workflow.my_workflow", "rules.0.sort_order"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/workflows/workflow_resource.go
+++ b/internal/provider/workflows/workflow_resource.go
@@ -228,18 +228,6 @@ func (r *WorkflowResource) Schema(ctx context.Context, req resource.SchemaReques
 															Description:         "Schedule applied to the approval entity.",
 															MarkdownDescription: "Schedule applied to the approval entity.",
 														},
-														"value": schema.SingleNestedAttribute{
-															Attributes: map[string]schema.Attribute{
-																"notified": schema.StringAttribute{
-																	Optional:            true,
-																	Description:         "",
-																	MarkdownDescription: "",
-																},
-															},
-															Optional:            true,
-															Description:         "value",
-															MarkdownDescription: "value",
-														},
 													},
 												},
 												Optional:            true,
@@ -304,18 +292,6 @@ func (r *WorkflowResource) Schema(ctx context.Context, req resource.SchemaReques
 															Optional:            true,
 															Description:         "Schedule applied to the approval entity.",
 															MarkdownDescription: "Schedule applied to the approval entity.",
-														},
-														"value": schema.SingleNestedAttribute{
-															Attributes: map[string]schema.Attribute{
-																"approval": schema.StringAttribute{
-																	Optional:            true,
-																	Description:         "Specifies the approval condition or requirement for the entity in this step. For example, it could indicate whether the approval is mandatory, optional, or has a certain threshold. This field helps customize the approval logic at a granular level.",
-																	MarkdownDescription: "Specifies the approval condition or requirement for the entity in this step. For example, it could indicate whether the approval is mandatory, optional, or has a certain threshold. This field helps customize the approval logic at a granular level.",
-																},
-															},
-															Required:            true,
-															Description:         "Holds additional metadata or configuration related to the entity’s role in the approval step. This can include specific rules, conditions, or statuses that influence how the approval or notification behaves.",
-															MarkdownDescription: "Holds additional metadata or configuration related to the entity’s role in the approval step. This can include specific rules, conditions, or statuses that influence how the approval or notification behaves.",
 														},
 													},
 												},

--- a/internal/provider/workflows/workflow_resource_test.go
+++ b/internal/provider/workflows/workflow_resource_test.go
@@ -1,0 +1,161 @@
+//go:build acceptance
+// +build acceptance
+
+package workflows_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/entitleio/terraform-provider-entitle/internal/testhelpers"
+)
+
+func TestWorkflowResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testhelpers.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testhelpers.ProviderConfig + fmt.Sprintf(`
+
+resource "entitle_workflow" "my_workflow" {
+	name = "My Workflow CI"
+	rules = [
+		{
+			sort_order = 1
+			in_groups = []
+			in_schedules = []
+			approval_flow = {
+				steps = [
+					{
+						sort_order = 1
+						notified_entities = [
+							{
+								type = "IntegrationOwner"
+							}
+						]
+						approval_entities = [
+							{
+								type = "IntegrationOwner"
+							},
+							{
+								type = "ResourceOwner"
+							}
+						]
+					},
+					{
+						sort_order = 1
+						notified_entities = [
+						]
+						approval_entities = [
+							{
+								type = "User"
+								user = {
+									id = "%s"
+								}
+							}
+						]
+					}
+				]
+			}
+		}
+	]
+}
+`, os.Getenv("ENTITLE_OWNER_ID")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "name", "My Workflow CI"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.sort_order", "1"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.0.sort_order", "1"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.0.approval_entities.0.type", "IntegrationOwner"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.0.approval_entities.1.type", "ResourceOwner"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.1.approval_entities.0.type", "User"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.1.approval_entities.0.user.id", os.Getenv("ENTITLE_OWNER_ID")),
+
+					// Verify default values
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.0.operator", "and"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.any_schedule", "true"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.under_duration", "3600"),
+
+					// Verify dynamic values have any value set in the state.
+					resource.TestCheckResourceAttrSet("entitle_workflow.my_workflow", "id"),
+					resource.TestCheckResourceAttrSet("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.1.approval_entities.0.user.email"),
+				),
+			},
+			// Update testing
+			{
+				Config: testhelpers.ProviderConfig + fmt.Sprintf(`
+
+resource "entitle_workflow" "my_workflow" {
+	name = "My Workflow CI UPDATED"
+	rules = [
+		{
+			sort_order = 1
+			in_groups = []
+			in_schedules = []
+			approval_flow = {
+				steps = [
+					{
+						sort_order = 1
+						notified_entities = [
+							{
+								type = "IntegrationOwner"
+								value = {
+								  notified = null
+								}
+							}
+						]
+						approval_entities = [
+							{
+								type = "ResourceOwner"
+							},
+							{
+								type = "IntegrationOwner"
+							}
+						]
+					},
+					{
+						sort_order = 1
+						notified_entities = [
+						]
+						approval_entities = [
+							{
+								type = "User"
+								user = {
+									id = "%s"
+								}
+							}
+						]
+					}
+				]
+			}
+		}
+	]
+}
+`, os.Getenv("ENTITLE_OWNER_ID")),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "name", "My Workflow CI UPDATED"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.sort_order", "1"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.0.sort_order", "1"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.0.approval_entities.0.type", "IntegrationOwner"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.0.approval_entities.1.type", "ResourceOwner"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.1.approval_entities.0.type", "User"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.1.approval_entities.0.user.id", os.Getenv("ENTITLE_OWNER_ID")),
+
+					// Verify default values
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.0.operator", "and"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.any_schedule", "true"),
+					resource.TestCheckResourceAttr("entitle_workflow.my_workflow", "rules.0.under_duration", "3600"),
+
+					// Verify dynamic values have any value set in the state.
+					resource.TestCheckResourceAttrSet("entitle_workflow.my_workflow", "id"),
+					resource.TestCheckResourceAttrSet("entitle_workflow.my_workflow", "rules.0.approval_flow.steps.1.approval_entities.0.user.email"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
- remove unnecessary value field from workflow approval and notified entities

This field was required for client, but only value client could pass to it is null, e.g.:
```
value = {
   approver = null
}
```
Probably it was created just to match api schema one to one, but it doesn't make sense to do so in terraform provider