### PR TITLE
fix: mark resource name field as immutable with RequiresReplace

### DIFF
--- a/internal/provider/resources/resource_resource.go
+++ b/internal/provider/resources/resource_resource.go
@@ -84,6 +84,9 @@ func (r *ResourceResource) Schema(ctx context.Context, req resource.SchemaReques
 				Validators: []validator.String{
 					validators.NewName(2, 50),
 				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"allowed_durations": schema.SetAttribute{
 				ElementType: types.NumberType,


### PR DESCRIPTION
### Jira Ticket
N/A

### Type
bug

### Title
fix: mark resource name field as immutable with RequiresReplace

### Additional Description

## Problem
Fixes #58

The `entitle_resource` name field was incorrectly configured to allow in-place updates, but the Entitle API does not support updating resource names after creation (`IntegrationResourcesUpdateBodySchema` does not include a `Name` field). This caused confusing "Invalid Configuration for Read-Only Attribute" errors when users attempted to rename resources.

## Solution
Added the `RequiresReplace()` plan modifier to the `name` attribute in the resource schema. This ensures that any name change triggers a destroy-and-recreate cycle instead of an attempted in-place update.

## Changes
- Added `stringplanmodifier.RequiresReplace()` to the `name` field schema in `internal/provider/resources/resource_resource.go`
- Updated generated documentation (via `go generate`)

## Testing
- Built and tested locally with Terraform
- Verified the schema now correctly indicates name changes require replacement
- Confirmed no breaking changes to existing resources (they will continue to work as-is)

## Impact
- **Breaking Change**: No - existing resources are unaffected
- **Bug Fix**: Yes - fixes the confusing error message
- **User Experience**: Users will now see a clear plan showing resource recreation when changing names

## Version Information
- Bug introduced in: v1.1.5 (commit fe20ce5, PR #26)
- Bug existed since: August 26, 2025
- Affects: All v1.1.5 users