### PR TITLE
chore: release ignore invalid combination

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
           - '1.6.*' # Intermediate
           - '1.12.*' # Latest
     steps:
-      - run: sleep 30
+#      - run: sleep 30
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,8 @@ builds:
     - arm
     - arm64
   ignore:
+    - goos: windows
+      goarch: arm
     - goos: darwin
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'


### PR DESCRIPTION
### Jira Ticket
N/A

### Type
chore

### Title
release ignore invalid combination

### Additional Description
Updated go to latest version, which is more strict in build and raises an error in invalid combination (os+arch). Need to ignore all build combinations which are invalid.