### PR TITLE
docs(README): sync supported resources and data sources, fix dev_overrides syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,44 @@
 />
 
 <h1>Entitle Terraform Provider</h1>
-<h5>In Development</h5>
 </div>
 
 The Terraform Provider for Entitle allows you to manage resources and data sources related to Entitle, a platform that provides a seamless way to grant employees granular and just-in-time access within cloud infrastructures and SaaS applications.
 
 ### Supported Resources
-* **Workflow** - A workflow in Entitle is a generic description of Just-In-Time permissions approval process, which is triggered after the permissions were requested by a user. Who should approve by approval order, to whom, and for how long. After the workflow is defined, it can be assigned to multiple entities which are part of the Just-In-Time permissions approval process: integrations, resources, roles and bundles.
-* **Integration** -A specific instance or integration with an "Application". Integration includes the configuration needed to connect Entitle including credentials, as well as all the users permissions information.
-* **Bundle** - Entitle bundle is a set of entitlements that can be requested, approved, or revoked by users in a single action, and set in a policy by the admin. Each entitlement can provide the user with access to a resource, which can be as fine-grained as a MongoDB table for example, usually by the use of a “Role”. Thus, one can think of a bundle as a cross-application super role.
-* **Policy** -  Entitle policy is a rule which manages users birthright permissions automatically, a group of users is entitled to a set of permissions. When a user joins the group, e.g. upon joining the organization, he will be granted with the permissions defined for the group automatically, and upon leaving the group, e.g. leaving the organization, the permissions will be revoked automatically.
-* **Agent Token** - On-prem agent token.
-* **Resource** - An entity within an "Integration" to which a user can gain access via an "Entitlement", e.g. DB table, group of users.
+* **Workflow** (`entitle_workflow`) — A Just-In-Time approval process: who approves, in what order, for how long. Assignable to integrations, resources, roles, and bundles.
+* **Integration** (`entitle_integration`) — A configured connection to a specific instance of an application (e.g. a particular AWS account, GitHub org, or Slack workspace), including credentials and access settings.
+* **Resource** (`entitle_resource`) — An entity within an integration that users can gain access to via a role (e.g. a database, repository, or user group).
+* **Role** (`entitle_role`) — The atomic permission unit within a resource (e.g. `readonly`, `admin`). Roles can carry their own workflow, allowed durations, and prerequisite permissions.
+* **Bundle** (`entitle_bundle`) — A cross-application package of roles that can be requested or revoked as a single action — effectively a "super role" spanning multiple integrations.
+* **Policy** (`entitle_policy`) — A rule that automatically grants birthright permissions to users in a group, and revokes them on group leave.
+* **Agent Token** (`entitle_agent_token`) — Credential used by the on-prem Entitle Agent to authenticate with the platform when connecting private/internal systems.
+* **Permission** (`entitle_permission`) — **Import-only.** Represents an active granted entitlement; created by Entitle through the request/approval flow. Use this to bring existing permissions under Terraform management for tracking or bulk revocation.
+* **Access Request Forward** (`entitle_access_request_forward`) — Delegates a user's pending access request responsibilities to a colleague (vacation, leave, role change).
+* **Access Review Forward** (`entitle_access_review_forward`) — Delegates a user's access review responsibilities during periodic review campaigns.
+
+### Supported Data Sources
+
+The provider also exposes 17 data sources for looking up existing Entitle objects (use these instead of hardcoding UUIDs in your configuration):
+
+| Singular (lookup one)              | Plural (list / filter)      |
+|------------------------------------|-----------------------------|
+| `entitle_user`                     | `entitle_users`             |
+| `entitle_role`                     | `entitle_roles`             |
+| `entitle_resource`                 | `entitle_resources`         |
+| `entitle_workflow`                 | —                           |
+| `entitle_bundle`                   | —                           |
+| `entitle_policy`                   | —                           |
+| `entitle_integration`              | —                           |
+| `entitle_agent_token`              | —                           |
+| `entitle_access_request_forward`   | —                           |
+| `entitle_access_review_forward`    | —                           |
+| —                                  | `entitle_accounts`          |
+| —                                  | `entitle_applications`      |
+| —                                  | `entitle_directory_groups`  |
+| —                                  | `entitle_permissions`       |
+
+See the [Terraform Registry documentation](https://registry.terraform.io/providers/entitleio/entitle/latest/docs) for full schemas.
 
 ## Prerequisites
 
@@ -74,7 +100,7 @@ before starting you need to overide the configuration for the terraform provider
 provider_installation {
 
   dev_overrides {
-      "entitleio/entitle" = `$GOPATH/bin`
+      "entitleio/entitle" = "/absolute/path/to/your/GOPATH/bin"  # e.g. "/Users/you/go/bin" — Terraform does not expand $GOPATH; the path must be literal
   }
 
   # For all other providers, install them directly from their origin provider


### PR DESCRIPTION
## Summary

- Sync the **Supported Resources** list to all 10 resources the provider actually exposes (adds `role`, `permission`, `access_request_forward`, `access_review_forward`) with terse, accurate one-liners and the canonical resource type for each.
- Add a new **Supported Data Sources** table listing all 17 data sources, grouped as singular-lookup vs plural-list/filter.
- Fix the `dev_overrides` HCL example — backticks aren't valid HCL string delimiters, and Terraform's CLI config doesn't expand shell variables, so `\`$GOPATH/bin\`` is doubly broken. Replace with a literal-path placeholder and an inline note.
- Drop the `<h5>In Development</h5>` header tag.

## Why

A prospective adopter landing on the GitHub README currently sees a smaller, less-mature provider than what actually ships:

- **6 resources listed; 10 exist.** `role`, `permission`, `access_request_forward`, and `access_review_forward` are all fully documented under `docs/resources/` and shipped to the registry — but absent from the README. This creates a false impression they aren't supported.
- **0 data sources listed; 17 exist.** Engineers want to discover lookup sources (`entitle_user`, `entitle_workflow`, `entitle_applications`, `entitle_directory_groups`, etc.) without leaving the repo.
- **Invalid HCL in `dev_overrides`** — `\"entitleio/entitle\" = \`\$GOPATH/bin\`` makes the very first build step in the README fail to parse for anyone copy-pasting.
- The **\"In Development\" tag** is inconsistent with the registry-published, Scorecard-rated, actively-maintained state of the repo (recent commits, releases, CodeQL/Scorecard badges all present at the top of the README).

## Out of scope (for follow-up PRs)

- **Per-application `connection_json` reference** — currently the integration docs say *\"you can get it on [this page](https://docs.beyondtrust.com/entitle/docs/integrations) or using [web ui create form]\"*, which forces users off the registry. A per-application schema table (Slack/AWS/GitHub/Okta/PostgreSQL/etc.) would close the single biggest documentation gap. Larger doc effort, separate PR.
- **Operations section** on the provider index page (drift behavior, retry/rate-limit handling, version pinning, CI guidance). Important for procurement reviews; separate PR.

## Test plan

- [ ] Visual review of rendered README on the \"Files changed\" tab — table renders correctly, headings nested correctly.
- [ ] Resource/data-source list matches `gh api repos/entitleio/terraform-provider-entitle/contents/docs/resources --jq '.[].name'` and `.../docs/data-sources` (10 and 17 entries respectively).
- [ ] (optional) `terraform fmt -check` on a temp file containing the new `dev_overrides` block parses without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)