### PR TITLE
bug: resolve api_key without quoting and honor env-only config

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -115,8 +115,8 @@ func (p *EntitleProvider) Configure(
 
 	// Validate and set API key.
 	token := os.Getenv("ENTITLE_API_KEY")
-	if !config.APIKey.IsUnknown() {
-		token = config.APIKey.String()
+	if !config.APIKey.IsNull() && !config.APIKey.IsUnknown() {
+		token = config.APIKey.ValueString()
 	}
 
 	if token == "" {


### PR DESCRIPTION
### Jira Ticket
N/A

### Type
bug

### Title
resolve api_key without quoting and honor env-only config

### Additional Description

The provider's API key resolution in `Configure` has two defects in the same two lines (`internal/provider/provider.go:118-119`):

**1. Quoted token on the wire.** `config.APIKey.String()` returns the *debug* representation of a `types.String`, which wraps the value in double quotes. So with `api_key` set in the provider block, the provider sends `Authorization: Bearer "MYTOKEN"`. This currently works only because the Entitle API tolerates the surrounding quotes — the acceptance suite (which configures the provider via the config block) passes against live orgs. It is a latent single-point-of-failure: any tightening of server-side token parsing would break **every** config-block customer at once.

**2. Env-only path is broken.** The guard `!config.APIKey.IsUnknown()` treats a *null* (unset) `api_key` as "known", so it overwrites the `ENTITLE_API_KEY` env value with the literal string `<null>` (`Authorization: Bearer <null>`). This breaks Option 2 of the documented configuration (`docs/index.md` — environment variable only, empty provider block).

#### Proof (running the provider's own `SetBearerToken` against the exact `Configure` logic)

| Path | Header before | After this fix |
|------|---------------|----------------|
| `api_key` in config block | `Bearer "MYTOKEN"` | `Bearer MYTOKEN` |
| `ENTITLE_API_KEY` env only | `Bearer <null>` | `Bearer MYTOKEN` |

#### Fix

```go
if !config.APIKey.IsNull() && !config.APIKey.IsUnknown() {
    token = config.APIKey.ValueString()
}
```

- `ValueString()` returns the raw value (no quotes).
- Guarding on `IsNull()` as well means an unset `api_key` no longer clobbers the env var.

This mirrors how the `endpoint` attribute is already resolved a few lines below (`IsNull()` + `ValueString()`).

#### Testing

- `go build ./...`, `gofmt`, `go vet ./internal/provider/` — clean.
- `go test ./internal/client/` — pass.
- Acceptance tests (`TF_ACC`) continue to use the config-block path and are unaffected (the server accepts both the quoted and unquoted forms).